### PR TITLE
feat: Add Manual Branch Coverage (Closes #1)

### DIFF
--- a/src/main/java/org/apache/commons/collections4/Coverage.java
+++ b/src/main/java/org/apache/commons/collections4/Coverage.java
@@ -22,9 +22,9 @@ public class Coverage {
     public static final boolean[] coverage_array  = new boolean[600]; // IDs 0..199
     private static boolean endPrint = false;
 
-    public static void hit(boolean[] arr, int id) {
+    public static void hit(int id) {
         // Mark your
-        arr[id] = true;
+        coverage_array[id] = true;
 
         if (!endPrint) {
             endPrint = true;


### PR DESCRIPTION
Class allowing us to keep track of branch coverage. You call hit() with a number according to [#1](https://github.com/DD2480-Group2/commons-collections/issues/1). Licience is needed becuase test wont run otherwise. Theoutput from the method wont print from mvn test but you have to manually test the class.