### PR TITLE
fix: Change the coverage part of the report (closes #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,8 +462,9 @@ Before:
 <img width="671" height="883" alt="image" src="https://github.com/user-attachments/assets/6348c786-9a01-467e-94aa-f614a70e1243" />
 
 After:
-<img width="1075" height="97" alt="image" src="https://github.com/user-attachments/assets/616eb0ff-eca1-43d1-b94b-012900659aa8" />
-<img width="560" height="728" alt="image" src="https://github.com/user-attachments/assets/7270395a-ef6a-4fe3-acc3-a3461466675f" />
+<img width="1421" height="127" alt="image" src="https://github.com/user-attachments/assets/4e4ab216-230a-4a26-869f-f7c8f36c0ddd" />
+<img width="671" height="885" alt="image" src="https://github.com/user-attachments/assets/629023a4-b72e-4423-b1ce-f350c785a61f" />
+
 
 ```
 /**

--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ Before:
 <img width="494" height="738" alt="image" src="https://github.com/user-attachments/assets/fea36010-87f5-4e20-aca4-7b51f1c50712" />
 <img width="503" height="391" alt="image" src="https://github.com/user-attachments/assets/02ce9d31-39d2-461c-9830-a666d0dae323" />
 
+After:
+<img width="1284" height="116" alt="image" src="https://github.com/user-attachments/assets/3c2e2046-d2d5-4a9f-97c7-abe41cdcff0e" />
+<img width="557" height="882" alt="image" src="https://github.com/user-attachments/assets/6dc3e8dd-f8cb-4f1b-a663-a150d92a8826" />
+<img width="561" height="467" alt="image" src="https://github.com/user-attachments/assets/580c8e87-34d5-4168-b5ef-844b07f43119" />
 
 Javadocs of the tests:
 ```
@@ -417,8 +421,9 @@ Test coverage before:
 <img width="1038" height="788" alt="image" src="https://github.com/user-attachments/assets/77f74493-220c-4821-8061-6c4ac704c429" />
 
 Test coverage after:
-<img width="1457" height="163" alt="image" src="https://github.com/user-attachments/assets/c135fb21-2b22-4b2a-bef0-b041f6664dd8" />
-<img width="1038" height="670" alt="image" src="https://github.com/user-attachments/assets/443b9954-f940-4fec-97a6-fd00749ce8fd" />
+<img width="1328" height="115" alt="image" src="https://github.com/user-attachments/assets/c294a331-5da4-4755-82fb-813a00e916c2" />
+<img width="1169" height="622" alt="image" src="https://github.com/user-attachments/assets/a897eb6e-f170-4bd3-b03f-999d0b62831c" />
+
 
 Tests comments:
 ```
@@ -448,8 +453,8 @@ Before:
 <img width="671" height="883" alt="image" src="https://github.com/user-attachments/assets/6348c786-9a01-467e-94aa-f614a70e1243" />
 
 After:
-<img width="1428" height="52" alt="image" src="https://github.com/user-attachments/assets/03415324-b7c5-4e13-bc1e-fa6f65bf5a19" />
-
+<img width="1075" height="97" alt="image" src="https://github.com/user-attachments/assets/616eb0ff-eca1-43d1-b94b-012900659aa8" />
+<img width="560" height="728" alt="image" src="https://github.com/user-attachments/assets/7270395a-ef6a-4fe3-acc3-a3461466675f" />
 
 
 ### Report of old coverage:

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ I also implemented a test for the equals method where no previous test confirmed
 ```
 
 #### Teoman:
+The previous tests did not handle hash collisions so I did 3 tests that each handled a hash collision, 1 test for each position in a 3 element long Flat3Map due to the switch statement that handles the function based on the elements positions. The 4th test checked that adding a fourth element with a null key still preserved every element
 
 Before:
 <img width="1420" height="125" alt="image" src="https://github.com/user-attachments/assets/3340bfdc-ce9f-4d12-ae26-56cadd803085" />
@@ -416,6 +417,8 @@ void testEquals7() {
 ```
 
 #### Adam:
+The branches that was not previously covered was those that handled invalid parameters. I wrote 3 tests checking that the parameters loadFactor, initialCapacity and concurrencyLevel throw the exception IllegalArgumentException when negative or 0 depending on the requirements. The 4th test was that concurrencyLevel was set to 1 << 16 when exceeding that max value. This covered 4 branches that was previously not tested. 
+
 Test coverage before:
 <img width="1473" height="127" alt="image" src="https://github.com/user-attachments/assets/d45418d1-4604-473e-8faa-2d031edf6859" />
 <img width="1038" height="788" alt="image" src="https://github.com/user-attachments/assets/77f74493-220c-4821-8061-6c4ac704c429" />
@@ -448,6 +451,12 @@ Tests comments:
 ```
 
 #### Ahmed:
+This method lacked tests that covered branches where the return should be null. I added these tests:
+1. a null lookup should return null if there are only non-null keys
+2. a lookup on an empty map should return null
+3. a lookup with a key that does not exist in the map should return null
+4. also made a test that makes sure maps of size 1 return correct value when given the right key. 
+
 Before:
 <img width="1418" height="65" alt="image" src="https://github.com/user-attachments/assets/1327f2af-e049-4aab-9a8f-a15c24e15341" />
 <img width="671" height="883" alt="image" src="https://github.com/user-attachments/assets/6348c786-9a01-467e-94aa-f614a70e1243" />
@@ -456,6 +465,30 @@ After:
 <img width="1075" height="97" alt="image" src="https://github.com/user-attachments/assets/616eb0ff-eca1-43d1-b94b-012900659aa8" />
 <img width="560" height="728" alt="image" src="https://github.com/user-attachments/assets/7270395a-ef6a-4fe3-acc3-a3461466675f" />
 
+```
+/**
+* Verifies that a null lookup returns null when the map contains only
+* non-null keys (size = 3, flat storage, full fall-through without match).
+*/
+```
+```
+/**
+* Verifies that a lookup on an empty map returns null
+* (non-null key, size = 0 branch).
+*/
+```
+```
+/**
+* Verifies successful retrieval when the key exists in a single-entry map
+* (size = 1, non-null key, direct match).
+*/
+```
+```
+/**
+* Verifies that a lookup returns null when the key is absent
+* in a non-empty map (size = 1, non-null key, no match).
+*/
+```
 
 ### Report of old coverage:
 

--- a/README.md
+++ b/README.md
@@ -197,17 +197,12 @@ Our tool supports `if`/`else` statements and `switch` cases, it can also handle 
 ### Show the comments that describe the requirements for the coverage.
 #### Kevin:
 The parts of the remove method that were not covered through the original tests were two checks for when the Map was full (3 elements) and we try to remove either key 1 or key 2 when the key itself is null. Before:  
+<img width="906" height="89" alt="image" src="https://github.com/user-attachments/assets/7a2f737d-e494-47ed-869f-aba476500cec" />
 <img width="408" height="638" alt="image" src="https://github.com/user-attachments/assets/9cbcafd4-fdc8-4db1-8afb-cc5ac64f0c2f" />
 
 After:  
-<img width="410" height="637" alt="image" src="https://github.com/user-attachments/assets/34085c85-2cef-48cd-af50-238178049f89" />
-
-Below we can see the branch coverage for the remove method:
-
-<img width="906" height="89" alt="image" src="https://github.com/user-attachments/assets/7a2f737d-e494-47ed-869f-aba476500cec" />
-and after:  
 <img width="912" height="86" alt="image" src="https://github.com/user-attachments/assets/64056e0d-83bd-4478-b186-ea76a6aece7d" />
-
+<img width="410" height="637" alt="image" src="https://github.com/user-attachments/assets/34085c85-2cef-48cd-af50-238178049f89" />
 
 Javadocs for the two methods covering the case above can be found below.
 ```
@@ -267,6 +262,7 @@ After:
 <img width="557" height="882" alt="image" src="https://github.com/user-attachments/assets/6dc3e8dd-f8cb-4f1b-a663-a150d92a8826" />
 <img width="561" height="467" alt="image" src="https://github.com/user-attachments/assets/580c8e87-34d5-4168-b5ef-844b07f43119" />
 
+Javadocs of the tests:
 ```
 /**
 * Tests that map is correctly delegated when size extends beyond three, and preserves elements.
@@ -424,6 +420,7 @@ void testEquals7() {
 The branches that was not previously covered was those that handled invalid parameters. I wrote 3 tests checking that the parameters loadFactor, initialCapacity and concurrencyLevel throw the exception IllegalArgumentException when negative or 0 depending on the requirements. The 4th test was that concurrencyLevel was set to 1 << 16 when exceeding that max value. This covered 4 branches that was previously not tested. 
 
 Test coverage before:
+<img width="1473" height="127" alt="image" src="https://github.com/user-attachments/assets/d45418d1-4604-473e-8faa-2d031edf6859" />
 <img width="1038" height="788" alt="image" src="https://github.com/user-attachments/assets/77f74493-220c-4821-8061-6c4ac704c429" />
 
 Test coverage after:
@@ -461,7 +458,8 @@ This method lacked tests that covered branches where the return should be null. 
 4. also made a test that makes sure maps of size 1 return correct value when given the right key. 
 
 Before:
-<img width="1424" height="66" alt="image" src="https://github.com/user-attachments/assets/db1493b2-7126-4491-bd92-b8b7d807762f" />
+<img width="1418" height="65" alt="image" src="https://github.com/user-attachments/assets/1327f2af-e049-4aab-9a8f-a15c24e15341" />
+<img width="671" height="883" alt="image" src="https://github.com/user-attachments/assets/6348c786-9a01-467e-94aa-f614a70e1243" />
 
 After:
 <img width="1421" height="127" alt="image" src="https://github.com/user-attachments/assets/4e4ab216-230a-4a26-869f-f7c8f36c0ddd" />

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ To obtain the patch, use the command ```git diff master..Development-Refactoring
 ## Coverage
 
 ### Tools
-We used JaCoCo as our automated coverage measurement tool. JoCoCo was already integrated into the project through Maven, which made it straightforward to use. We generated a coverage report by running ```mvn test``` and then ```mvn jacoco:report```.
+We used JaCoCo as our automated coverage measurement tool. JaCoCo was already integrated into the project through Maven, which made it straightforward to use. We generated a coverage report by running ```mvn test``` and then ```mvn jacoco:report```.
 
 JaCoCo then produced a HTML report that provided information about instruction coverage, branch coverage and other key-values for analyzing the repo both on class level and on method level.
 
@@ -175,7 +175,7 @@ We implemented a simple manual branch coverage tool by instrumenting the selecte
 Our branch for instrumented code to gather coverage measurements:
 [Development-Coverage branch](https://github.com/DD2480-Group2/commons-collections/tree/Development-Coverage)
 
-To obtain the patch, use the command ```git diff master..Development-Coverage```
+To obtain the patch, use the command ```git diff master..Development-Coverage src```
 
 Our tool supports `if`/`else` statements and `switch` cases, it can also handle loops but only as a way of seeing if at least one iteration of the loop was performed.
 
@@ -187,7 +187,7 @@ Our tool supports `if`/`else` statements and `switch` cases, it can also handle 
 2. What are the limitations of your own tool?
    The limitations in our implemented tool lies partly in when if-statements contain multiple conditionals connected by ```&&``` and ```||```, since our tool can only explore the branches the code goes to, we do not explore the different combinations of conditionals inside the if-statement, but only when the if-statement results in true or false. There is also currently limitations regarding how loops are handled, since we only explore different branches, we can only explore if we enter a loop or not, but not how many times we iterate.
 
-but we can not explore some of the branches that JaCoCo explores through conditional statements including ```&&``` & ```||```. Due to this our output might be interpreted as if a higher percentage of the branches are being covered, compared to JaCoCo’s output. So our
+	but we can not explore some of the branches that JaCoCo explores through conditional statements including ```&&``` & ```||```. Due to this our output might be interpreted as if a higher percentage of the branches are being covered, compared to JaCoCo’s output. So our
 
 3. Are the results of your tool consistent with existing coverage tools?
    The output is somewhat aligned with what JaCoCo outputs with exceptions for when the code contains if-statements containing multiple conditionals connected through ```&&``` and ```||```, since JaCoCo explores all possible combinations of parameters for the if-statement, our tool simply explores the if-statement as true or false. This makes it so our tool tells a story of a higher branch coverage than might be present, whereas JaCoCo will determine more possible branch outcomes.


### PR DESCRIPTION
Added pictures of JaCoCo and descriptions of the tests

The structure is now a short description of tests first, followed by JaCoCo screenshots before and after, followed by the tests comments